### PR TITLE
bug fixes for date format

### DIFF
--- a/Sources/Date.swift
+++ b/Sources/Date.swift
@@ -46,6 +46,7 @@ public extension NSDate {
         let dateFmt = NSDateFormatter()
         dateFmt.timeZone = NSTimeZone.defaultTimeZone()
         dateFmt.dateFormat = format
+        dateFmt.calendar = NSCalendar(calendarIdentifier: NSCalendarIdentifierISO8601)
         return dateFmt.dateFromString(dateStr)!
     }
     


### PR DESCRIPTION
There's a bug of NSDateFormatter, it happens with the first day of daylight saving time every year, the date will be nil which will crash your code.
More info at [here](http://stackoverflow.com/questions/32408898/nsdateformatter-datefromstring-returns-nil-for-specific-dates-in-specific-langua).
