### PR TITLE
Xcode 10: Fixed Int extension isIn redeclaration

### DIFF
--- a/Sources/Int.swift
+++ b/Sources/Int.swift
@@ -162,14 +162,6 @@ public extension Int {
         return Dollar.it(self, isIn: Range(interval))
     }
 
-    /// Returns true if i is in closed interval
-    ///
-    /// - parameter interval: to check in
-    /// - returns: true if it is in interval otherwise false
-    public func isIn(interval: CountableClosedRange<Int>) -> Bool {
-        return Dollar.it(self, isIn: Range(interval))
-    }
-
     /// Returns true if i is in half open interval
     ///
     /// - parameter interval: to check in

--- a/Tests/CentTests/CentTests.swift
+++ b/Tests/CentTests/CentTests.swift
@@ -283,6 +283,13 @@ class CentTests: XCTestCase {
     /**
         Int Test Cases
     */
+    
+    func testIntRange() {
+        XCTAssertTrue(0.isIn(interval: 0...2), "Should return true")
+        XCTAssertTrue(1.isIn(interval: 0...2), "Should return true")
+        XCTAssertTrue(2.isIn(interval: 0...2), "Should return true")
+        XCTAssertFalse(3.isIn(interval: 0...2), "Should return false")
+    }
 
     func testDateMath() {
         let calendar = Calendar.current


### PR DESCRIPTION
`CountableClosedRange<Bound>` is now a typealias of `ClosedRange<Bound>` in Xcode 10.
https://developer.apple.com/documentation/swift/countableclosedrange

As a result the following `Int` extension methods resulted in a function redeclaration error.
`isIn(interval: CountableClosedRange<Int>) -> Bool`
`isIn(interval: ClosedRange<Int>) -> Bool`

This pull request simply removes the `isIn(interval: CountableClosedRange<Int>) -> Bool` method. It also adds some simple tests for `isIn`.