### PR TITLE
Switch order of code samples

### DIFF
--- a/README.md
+++ b/README.md
@@ -401,8 +401,8 @@ dic.merge(anotherDic)
 Invoke a callback n times with callback that takes index
 
 ```swift
-5.times { print("Na") } 
-=> "NaNaNaNaNa"
+5.times { (a: Int) -> () in print("\(a) ") } 
+=> 0 1 2 3 4  
 ```
 
 ### `times (function: () -> ())`
@@ -410,8 +410,8 @@ Invoke a callback n times with callback that takes index
 Invoke a callback n times
 
 ```swift
-5.times { (a: Int) -> () in print("\(a) ") } 
-=> 0 1 2 3 4  
+5.times { print("Na") } 
+=> "NaNaNaNaNa"
 ```
 
 ### `char -> Character`


### PR DESCRIPTION
The code samples for `Int.times` were mixed up in regard to the headings, so this PR fixes them.
